### PR TITLE
Express compliance using float value

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,8 @@ function applyRules(rules, record) {
             field_id: rule.field_id,
             field: key,
             value: (() => (rule.normalize && rule.normalize(value)))() || value,
-            is_compliant: compliantRec.value,
+            is_compliant: (compliantRec.value >= 0.5),
+            is_compliant_float: compliantRec.value,
             guidelines: rule.guidelines,
             gmga: rule.gmga,
             is_compliant_expr: (

--- a/roarmap-rules.js
+++ b/roarmap-rules.js
@@ -17,10 +17,12 @@ exports.NEXA_RULES = {
         field_id: 10,
         compliantValues: (v, r) => (
           (["acceptance", "publication"].indexOf(v) >= 0)
-            ? true
+            ? 1.0
             : (v === "embargo" &&
                   ["0m", "6m", "12m"].indexOf(r.embargo_hum_soc) >= 0 &&
                   ["0m", "6m"].indexOf(r.embargo_sci_tech_med) >= 0)
+              ? 2.0
+              : false
         ),
         guidelines: 3.14,
         gmga: "29.2.2.b",
@@ -95,7 +97,13 @@ exports.NEXA_RULES = {
     maximal_embargo_waivable: {
         meg_id: 11,
         field_id: 17,
-        compliantValues: ["no", "not_specified"],
+        compliantValues: (v) => (
+          (["no", "not_specified"].indexOf(v) >= 0)
+            ? true
+            : (v === "yes")
+              ? 0.25
+              : false
+        ),
         guidelines: 3.14,
         gmga: "29.2.2.b",
     },
@@ -103,7 +111,13 @@ exports.NEXA_RULES = {
     waive_open_access: {
         meg_id: 12,
         field_id: 9,
-        compliantValues: "no",
+        compliantValues: (v) => (
+          (v === "no")
+            ? 0.75
+            : (v === "yes")
+              ? 0.25
+              : false
+        ),
         gmga: ["29.1.1", "29.1.2"],
     },
 


### PR DESCRIPTION
Anything lower than 0.5 is considered false, all other values
are considered obviously true.

This specific encoding of compliance allows to express:

a) which specific clause was matched (this is used for example
   in `date_made_open` compliance computation)

b) cases where it's more yes then no and viceversa

The `is_compliant` field is unchanged (this was verified by
checking the result of `node index.js -t` against the previous
result emitted by that command). A new field `is_compliant_float`
has been added to allow one to access the nuanced value.

This more or less supersedes #10, but the part of #10 emitting
the proper strings could still be useful.
