### PR TITLE
Remove ECMA6 goodies from lib/rules.js

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -4,7 +4,7 @@
 "use strict";
 
 // Rules to evaluate compliancy according to Nexa Center
-const NEXA_RULES = {
+var NEXA_RULES = {
     can_deposit_be_waived: {
         meg_id: 1,
         field_id: 7,
@@ -15,7 +15,7 @@ const NEXA_RULES = {
     date_made_open: {
         meg_id: 2,
         field_id: 10,
-        compliantValues: (v, r) => (
+        compliantValues: function (v, r) { return (
           (["acceptance", "publication"].indexOf(v) >= 0)
             ? 1.0
             : (v === "embargo" &&
@@ -23,7 +23,7 @@ const NEXA_RULES = {
                   ["0m", "6m"].indexOf(r.embargo_sci_tech_med) >= 0)
               ? 2.0
               : false
-        ),
+        ); },
         guidelines: 3.14,
         gmga: "29.2.2.b",
     },
@@ -63,11 +63,13 @@ const NEXA_RULES = {
     gold_oa_options: {
         meg_id: 7,
         field_id: 19,
-        compliantValues: () => true,
+        compliantValues: function () { return true; },
         guidelines: [3.5, 3.13, 3.15],
         gmga: "29.2.2.b",
-        normalize: (v) => ((v === "reccomended") ? "recommended" :
-                           (v === "reqired") ? "required" : v),
+        normalize: function (v) { return (
+            ((v === "reccomended") ? "recommended" :
+                           (v === "reqired") ? "required" : v)
+        ); },
     },
 
     journal_article_version: {
@@ -97,13 +99,13 @@ const NEXA_RULES = {
     maximal_embargo_waivable: {
         meg_id: 11,
         field_id: 17,
-        compliantValues: (v) => (
+        compliantValues: function (v) { return (
           (["no", "not_specified"].indexOf(v) >= 0)
             ? true
             : (v === "yes")
               ? 0.25
               : false
-        ),
+        ); },
         guidelines: 3.14,
         gmga: "29.2.2.b",
         fuzzyLabels: {
@@ -118,13 +120,13 @@ const NEXA_RULES = {
     waive_open_access: {
         meg_id: 12,
         field_id: 9,
-        compliantValues: (v) => (
+        compliantValues: function (v) { return (
           (v === "no")
             ? 0.75
             : (v === "yes")
               ? 0.25
               : false
-        ),
+        ); },
         gmga: ["29.1.1", "29.1.2"],
         fuzzyLabels: {
             0.75: "However, please note that Open Access must be " +
@@ -145,15 +147,15 @@ const NEXA_RULES = {
 
     mandate_content_types: {
         field_id: 5,
-        compliantValues: (value) => (
+        compliantValues: function (value) { return (
             value.indexOf("not_specified") < 0
-        ),
+        ); },
         guidelines: [3.1, 3.3, 3.4, 3.11],
         gmga: ["29.2.1", "29.2.2.a.2"],
     },
 };
 
-const evaluateRule = (rule, record, key, value) => {
+var evaluateRule = function (rule, record, key, value) {
     var compliantValues = rule.compliantValues,
         initialExpr = compliantValues;
     var compliant = ((typeof compliantValues === "string" &&
@@ -170,8 +172,8 @@ const evaluateRule = (rule, record, key, value) => {
     };
 }
 
-const applyRules = exports.applyRules = (record) => {
-    const rules = NEXA_RULES;
+var applyRules = exports.applyRules = function (record) {
+    var rules = NEXA_RULES;
     var newRecord = [];
     Object.keys(rules).forEach(function (key) {
         var rule = rules[key],
@@ -180,7 +182,9 @@ const applyRules = exports.applyRules = (record) => {
         newRecord.push({
             field_id: rule.field_id,
             field: key,
-            value: (() => (rule.normalize && rule.normalize(value)))() || value,
+            value: (function () {
+                return (rule.normalize && rule.normalize(value));
+            })() || value,
             is_compliant: (compliantRec.value >= 0.5),
             is_compliant_float: compliantRec.value,
             guidelines: rule.guidelines,


### PR DESCRIPTION
If we're to use this file in the frontend, we'd better make
sure that we don't use ECMA6 to be backwards compatible.

This is a pity, because ECMA6 rocks, but I cannot bet on people
using this service to always have the latest browser.
