### PR TITLE
rules.js: break long expression

### DIFF
--- a/lib/common/rules.js
+++ b/lib/common/rules.js
@@ -16,9 +16,15 @@ var NEXA_RULES = {
         meg_id: 2,
         field_id: 10,
         compliantValues: function (v, r) {
-            return (
-                (["acceptance", "publication"].indexOf(v) >= 0) ? 1.0 : (v === "embargo" && ["0m", "6m", "12m"].indexOf(r.embargo_hum_soc) >= 0 && ["0m", "6m"].indexOf(r.embargo_sci_tech_med) >= 0) ? 2.0 : false
-            );
+            if (["acceptance", "publication"].indexOf(v) >= 0) {
+                return 1.0;
+            }
+            if (v === "embargo" && ["0m", "6m", "12m"].indexOf(
+                        r.embargo_hum_soc) >= 0 && ["0m", "6m"].indexOf(
+                        r.embargo_sci_tech_med) >= 0) {
+                return 2.0;
+            }
+            return false;
         },
         guidelines: 3.14,
         gmga: "29.2.2.b",


### PR DESCRIPTION
Verified by compating `node server.js -t` output file with existing fixture
file that no regression was introduced by this commit.
